### PR TITLE
add libgfortran as host requirement for linux

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
   host:
     - m2w64-toolchain  # [win]
     - libpython  # [win]
+    - libgfortran  # [linux]
     - python 
     - numpy >=1.12 
     - scipy


### PR DESCRIPTION
linux build for Python 3.6 with gfortran was using libgfrotran-ng and errored

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
